### PR TITLE
Add and remove DevAddr blocks via CLI

### DIFF
--- a/cmd/internal/pbflag/pbflag.go
+++ b/cmd/internal/pbflag/pbflag.go
@@ -217,16 +217,22 @@ func (f *devAddrBlocksValue) Type() string {
 }
 
 // DevAddrBlocks returns flags for DevAddr blocks.
-func DevAddrBlocks() *flag.FlagSet {
+func DevAddrBlocks(addRemove bool) *flag.FlagSet {
 	flags := new(flag.FlagSet)
 	flags.Var(new(devAddrBlocksValue), "dev-addr-blocks", "DevAddr blocks")
+	if addRemove {
+		flags.Var(new(devAddrBlocksValue), "dev-addr-blocks-add", "DevAddr blocks to add")
+		flags.Var(new(devAddrBlocksValue), "dev-addr-blocks-remove", "DevAddr blocks to remove")
+	}
 	return flags
 }
 
 // GetDevAddrBlocks returns the DevAddr blocks from the flags.
-func GetDevAddrBlocks(flags *flag.FlagSet) []*packetbroker.DevAddrBlock {
-	blocks := flags.Lookup("dev-addr-blocks").Value.(*devAddrBlocksValue)
-	return []*packetbroker.DevAddrBlock(*blocks)
+func GetDevAddrBlocks(flags *flag.FlagSet) (all, add, remove []*packetbroker.DevAddrBlock) {
+	all = []*packetbroker.DevAddrBlock(*flags.Lookup("dev-addr-blocks").Value.(*devAddrBlocksValue))
+	add = []*packetbroker.DevAddrBlock(*flags.Lookup("dev-addr-blocks-add").Value.(*devAddrBlocksValue))
+	remove = []*packetbroker.DevAddrBlock(*flags.Lookup("dev-addr-blocks-remove").Value.(*devAddrBlocksValue))
+	return
 }
 
 type joinEUIPrefixesValue []*packetbroker.JoinEUIPrefix


### PR DESCRIPTION
<!--
Thanks for submitting a pull request. Please fill the template below,
otherwise we will not be able to process this pull request.
-->

#### Summary
<!--
A short summary, referencing related issues:
Closes #0000, References #0000, etc.
-->

Add and remove DevAddr blocks via CLI

#### Changes
<!-- What are the changes made in this pull request? -->

This adds `--dev-addr-blocks-add` and `--dev-addr-blocks-remove` to the network and tenant update commands.

This can be used to just add or remove blocks without specifying all blocks.

